### PR TITLE
[--compatible-with package.json] Change the range of max version satisfying the compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@softonic/ci-version",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "CLI program to determine new versions in CI projects",
   "main": "index.js",
   "bin": {

--- a/src/createVersion.js
+++ b/src/createVersion.js
@@ -15,7 +15,7 @@ function createCompatibleVersion({ currentVersions, allVersions, compatibleWith 
     return null;
   }
 
-  const maxCompatible = semver.maxSatisfying(allVersions, `^${compatibleWith}`);
+  const maxCompatible = semver.maxSatisfying(allVersions, `>${compatibleWith}`);
   if (!maxCompatible) {
     return compatibleWith;
   }


### PR DESCRIPTION
As commented here: https://github.com/softonic/ci-version/issues/4

The result is not the expected in this scenario:
Current commit tags: 
All tags: 0.1.0 0.2.0 0.3.0
package.json/composer.json: 0.1.0
=> New version: 0.2.0

New version should be 0.4.0 instead.
